### PR TITLE
xdma: support 64bits coherent addressing

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -3902,9 +3902,7 @@ static int set_dma_mask(struct pci_dev *pdev)
 		dbg_init("pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
-		/* use 32-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
-		/* use 64-bit DMA, 32-bit for consistent */
+		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
 	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
 		dbg_init("Could not set 64-bit DMA mask.\n");
 		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));


### PR DESCRIPTION
When the pci node dma_start address is above 32bits range, the dma_alloc_coherent calls will fail because of the dma_coherent mask which is on 32bits only.
Use a 64bits dma_coherent_mask to fix this.